### PR TITLE
Fix compilation on linux.

### DIFF
--- a/tun.c
+++ b/tun.c
@@ -17,6 +17,9 @@
 #include <unistd.h>
 
 #define MTU 1500
+#ifndef INFTIM
+#define INFTIM	(-1)
+#endif
 
 struct packet {
 	int family;


### PR DESCRIPTION
From `man 2 poll`:
>Some  implementations  define the nonstandard constant INFTIM with the
>value -1 for use as a timeout for poll().  This constant is  not  pro-
>vided in glibc.